### PR TITLE
feat(eslint-plugin): add vue support to copyright-text rule

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -24,9 +24,9 @@
     "LICENSE"
   ],
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.js",
-    "require": "./dist/index.cjs",
-    "types": "./dist/index.d.ts"
+    "require": "./dist/index.cjs"
   },
   "scripts": {
     "dev": "tsup --watch",

--- a/packages/eslint-plugin/src/constants/copyright.ts
+++ b/packages/eslint-plugin/src/constants/copyright.ts
@@ -1,12 +1,10 @@
 export const DEFAULT_START_YEAR = 2017;
 
 export const COPYRIGHT_TEXT = `
-/*
  * Copyright {startYear}-{currentYear} Commencis. All Rights Reserved.
  *
  * Save to the extent permitted by law, you may not use, copy, modify,
  * distribute or create derivative works of this material or any part
  * of it without the prior written consent of Commencis.
  * Any reproduction of this material must contain this notice.
- */
 `.trim();

--- a/packages/eslint-plugin/src/rules/copyright-text.ts
+++ b/packages/eslint-plugin/src/rules/copyright-text.ts
@@ -40,7 +40,9 @@ export default createRule<[RuleOptions], MessageIds>({
 
   create(context, [options]) {
     const startYear = options.startYear ?? DEFAULT_START_YEAR;
-    const expectedCopyrightText = getCopyrightText(startYear);
+    const isHtml = context.filename.endsWith('.vue');
+
+    const expectedCopyrightText = getCopyrightText(startYear, isHtml);
 
     return {
       Program(node: TSESTree.Program) {

--- a/packages/eslint-plugin/src/utils/getCopyrightText.ts
+++ b/packages/eslint-plugin/src/utils/getCopyrightText.ts
@@ -1,9 +1,15 @@
 import { COPYRIGHT_TEXT } from '@/constants/copyright';
 
-export function getCopyrightText(startYear: number): string {
+export function getCopyrightText(startYear: number, isHtml: boolean): string {
   const currentYear = new Date().getFullYear();
-  return COPYRIGHT_TEXT.replace(/{startYear}/g, startYear.toString()).replace(
-    /{currentYear}/g,
-    currentYear.toString()
-  );
+
+  const formattedText = COPYRIGHT_TEXT.replace(
+    /{startYear}/g,
+    startYear.toString()
+  ).replace(/{currentYear}/g, currentYear.toString());
+
+  if (isHtml) {
+    return `<!--\n ${formattedText}\n-->`;
+  }
+  return `/*\n ${formattedText}\n */`;
 }


### PR DESCRIPTION
- for `.vue` files copyright-text will be wrapped in html-comments syntax
- fix conditional exports, `types` field should included first