### PR TITLE
feat(eslint-config): add new react & typescript rules

### DIFF
--- a/packages/eslint-config/src/rules/reactRules.ts
+++ b/packages/eslint-config/src/rules/reactRules.ts
@@ -16,4 +16,7 @@ export const reactRules: Linter.RulesRecord = {
   // https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint
   'react/jsx-uses-react': 'off',
   'react/react-in-jsx-scope': 'off',
+
+  // We are not planning to utilize rules below
+  'react/jsx-props-no-spreading': 'off',
 };

--- a/packages/eslint-config/src/rules/typescriptRules.ts
+++ b/packages/eslint-config/src/rules/typescriptRules.ts
@@ -3,4 +3,7 @@ import { Linter } from '@typescript-eslint/utils/ts-eslint';
 export const typescriptRules: Linter.RulesRecord = {
   '@typescript-eslint/consistent-type-definitions': 'off',
   '@typescript-eslint/no-empty-function': 'off',
+  '@typescript-eslint/array-type': 'off',
+
+  '@typescript-eslint/explicit-function-return-type': 'error',
 };


### PR DESCRIPTION
After the discussion we had with the team, we decided to make following changes in our eslint rules:

- Disable `react/jsx-props-no-spreading`
- Disable `@typescript-eslint/array-type`
- Enable `@typescript-eslint/explicit-function-return-type`