### PR TITLE
feat(eslint-config): update import sort for commons

### DIFF
--- a/.changeset/spicy-berries-cough.md
+++ b/.changeset/spicy-berries-cough.md
@@ -1,0 +1,5 @@
+---
+'@commencis/eslint-config': patch
+---
+
+update import sort of common directories

--- a/.changeset/spicy-berries-cough.md
+++ b/.changeset/spicy-berries-cough.md
@@ -2,4 +2,5 @@
 '@commencis/eslint-config': patch
 ---
 
-update import sort of common directories
+update import sort of common directories:
+`config`, `types`, `interfaces`, `constants`, `helpers`, `utils`, `lib`

--- a/packages/eslint-config/src/rules/importSortRules.ts
+++ b/packages/eslint-config/src/rules/importSortRules.ts
@@ -23,15 +23,13 @@ export const importSortRules: Linter.RulesRecord = {
         ['^@commencis', '^@?\\w'],
 
         // Internal common directories
-        [
-          '^@?/?(configs(s?)|types(s?)|constants(s?)|helpers(s?)|utils(s?)|lib(s?)|providers(s?))(/.*|$)',
-        ],
+        ['^@?/?(config|types|interfaces|constants|helpers|utils|lib)(/.*|$)'],
 
         // Internal directories
         ['^@/'],
 
         // Components
-        ['((.*)/)?(layouts|pages|modules|features|components)/'],
+        ['((.*)/)?(providers|layouts|pages|modules|features|components)/'],
 
         // Relative parent imports: '../' comes last
         ['^\\.\\.(?!/?$)', '^\\.\\./?$'],


### PR DESCRIPTION
- update import sort for grouping common directories:
`config`, `types`, `interfaces`, `constants`, `helpers`, `utils`, `lib`