### PR TITLE
fix(eslint-config): increase coverage for edge cases in sorting rules

### DIFF
--- a/packages/eslint-config/src/rules/importSortRules.ts
+++ b/packages/eslint-config/src/rules/importSortRules.ts
@@ -10,7 +10,7 @@ export const importSortRules: Linter.RulesRecord = {
 
         // Main frameworks & libraries
         [
-          '^react',
+          '^(react(-native|-dom)?(/.*)?)$',
           '^next',
           '^vue',
           '^nuxt',
@@ -29,7 +29,7 @@ export const importSortRules: Linter.RulesRecord = {
         ['^@/'],
 
         // Components
-        ['((.*)/)?(providers|layouts|pages|modules|features|components)/'],
+        ['((.*)/)?(providers|layouts|pages|modules|features|components)/?'],
 
         // Relative parent imports: '../' comes last
         ['^\\.\\.(?!/?$)', '^\\.\\./?$'],


### PR DESCRIPTION
With this PR, we are covering two more edge cases in our import sorting.